### PR TITLE
Add ssl trust system parameter to the email extension.

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/io/email/sink/EmailSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/email/sink/EmailSink.java
@@ -195,6 +195,13 @@ import java.util.Map;
                                 + "define stream fooStream (name string, age int, country string);"),
         },
         systemParameter = {
+                @SystemParameter(name = "mail.smtp.ssl.trust",
+                                 description = "If set, and a socket factory hasn't been specified, enables use of a "
+                                         + "MailSSLSocketFactory. If set to \"*\", all hosts are trusted. If set to a"
+                                         + " whitespace separated list of hosts, those hosts are trusted. Otherwise, "
+                                         + "trust depends on the certificate the server presents.",
+                                 defaultValue = "*",
+                                 possibleParameters = "String"),
                 @SystemParameter(name = "mail.smtp.connectiontimeout",
                                  description = "Socket connection timeout value in milliseconds. ",
                                  defaultValue = "infinite timeout",
@@ -536,6 +543,12 @@ public class EmailSink extends Sink {
             }
         }
         initProperties.put(EmailConstants.TRANSPORT_MAIL_PUBLISHER_PORT, port);
+
+        //Default we trust all the hosts (smtp servers). If user need to trust set of hosts then, it is required to
+        //set 'ssl.trust' system property in deployment yaml under email sink configuration.
+        String trust = configReader.readConfig(EmailConstants.MAIL_PUBLISHER_TRUST,
+                EmailConstants.EMAIL_RECEIVER_DEFAULT_TRUST);
+        initProperties.put(EmailConstants.MAIL_PUBLISHER_TRUST, trust);
 
         //to is a dynamic variable, if that option is not exist,
         // check whether default value for the 'to' is given in the configurations.

--- a/component/src/main/java/org/wso2/extension/siddhi/io/email/source/EmailSource.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/email/source/EmailSource.java
@@ -318,7 +318,7 @@ import java.util.stream.Stream;
                                 + "If set to '*', all hosts are trusted."
                                 + "If set to a whitespace separated list of hosts, those hosts are trusted."
                                 + "Otherwise, trust depends on the certificate the server presents.",
-                        defaultValue = "None",
+                        defaultValue = "*",
                         possibleParameters = "Valid String"),
                 @SystemParameter(name = "mail.imap.ssl.socketFactory",
                         description = "If set to a class that extends the javax.net.ssl.SSLSocketFactory class,"
@@ -435,7 +435,7 @@ import java.util.stream.Stream;
                                 + "If set to '*', all hosts are trusted."
                                 + "If set to a whitespace separated list of hosts, those hosts are trusted."
                                 + "Otherwise, trust depends on the certificate the server presents.",
-                        defaultValue = "Depends on the certificate the server presents",
+                        defaultValue = "*",
                         possibleParameters = "Valid String"),
                 @SystemParameter(name = "mail.pop3.ssl.socketFactory",
                         description = "If set to a class that extends the javax.net.ssl.SSLSocketFactory class,"
@@ -861,5 +861,11 @@ public class EmailSource extends Source {
             + "' and '" + EmailConstants.TEXT_PLAIN + "' but found: " + contentType + ".");
         }
         properties.put(EmailConstants.TRANSPORT_MAIL_RECEIVER_CONTENT_TYPE, contentType);
+
+        //Default we trust all the hosts (imap and pop3 servers). If user need to trust set of hosts then,
+        // it is required to set 'ssl.trust' system property in deployment yaml under email source configuration.
+        String trust = configReader.readConfig("mail." + store + "." + EmailConstants.EMAIL_RECEIVER_TRUST,
+                EmailConstants.EMAIL_RECEIVER_DEFAULT_TRUST);
+        properties.put("mail." + store + "." + EmailConstants.EMAIL_RECEIVER_TRUST, trust);
     }
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/email/util/EmailConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/email/util/EmailConstants.java
@@ -84,7 +84,6 @@ public class EmailConstants {
     public static final String EMAIL_SEARCH_TERM = "search.term";
     public static final String EMAIL_RECEIVER_TRUST = "ssl.trust";
 
-
     /**
      * Default values for the email source configurations.
      */

--- a/component/src/main/java/org/wso2/extension/siddhi/io/email/util/EmailConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/email/util/EmailConstants.java
@@ -32,6 +32,7 @@ public class EmailConstants {
     public static final String MAIL_PUBLISHER_PASSWORD = "password";
     public static final String MAIL_PUBLISHER_HOST_NAME = "host";
     public static final String MAIL_PUBLISHER_SSL_ENABLE = "ssl.enable";
+    public static final String MAIL_PUBLISHER_TRUST = "mail.smtp.ssl.trust";
     public static final String MAIL_PUBLISHER_PORT = "port";
     public static final String MAIL_PUBLISHER_AUTH = "auth";
     public static final String MAIL_PUBLISHER_CONTENT_TYPE = "content.type";
@@ -48,6 +49,7 @@ public class EmailConstants {
     public static final String MAIL_PUBLISHER_DEFAULT_PORT = "465";
     public static final String MAIL_PUBLISHER_DEFAULT_AUTH = "true";
     public static final String MAIL_PUBLISHER_DEFAULT_CONTENT_TYPE = "text/plain";
+    public static final String MAIL_PUBLISHER_DEFAULY_TRUST = "*";
 
     /**
      * Required carbon transport properties to send the email.
@@ -80,6 +82,8 @@ public class EmailConstants {
     public static final String FOLDER = "folder";
     public static final String MOVE_TO_FOLDER = "move.to.folder";
     public static final String EMAIL_SEARCH_TERM = "search.term";
+    public static final String EMAIL_RECEIVER_TRUST = "ssl.trust";
+
 
     /**
      * Default values for the email source configurations.
@@ -91,6 +95,7 @@ public class EmailConstants {
     public static final String DEFAULT_POLLING_INTERVAL = "600";
     public static final String EMAIL_RECEIVER_DEFAULT_CONTENT_TYPE = "text/plain";
     public static final String DEFAULT_AUTO_ACKNOWLEDGE = "false";
+    public static final String EMAIL_RECEIVER_DEFAULT_TRUST = "*";
 
     /**
      * Required carbon transport properties to receive the email.


### PR DESCRIPTION
## Purpose
> Add SSL trust system parameter to the email extension.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
