### PR TITLE
Fixing bug: Wrong error message given when "address" parameter is missing

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/io/email/sink/EmailSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/email/sink/EmailSink.java
@@ -494,7 +494,7 @@ public class EmailSink extends Sink {
         String address = optionHolder.validateAndGetStaticValue(EmailConstants.MAIL_PUBLISHER_ADDRESS,
                 configReader.readConfig(EmailConstants.MAIL_PUBLISHER_ADDRESS, EmailConstants.EMPTY_STRING));
         if (address.isEmpty()) {
-            throw new SiddhiAppCreationException(EmailConstants.MAIL_PUBLISHER_USERNAME + " is a mandatory parameter. "
+            throw new SiddhiAppCreationException(EmailConstants.MAIL_PUBLISHER_ADDRESS + " is a mandatory parameter. "
                     + "It should be defined in either stream definition or deployment 'yaml' file.");
         }
         emailProperties.put(EmailConstants.TRANSPORT_MAIL_HEADER_FROM, address);


### PR DESCRIPTION
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
