### PR TITLE
Fix the exception handling issue in Email Sink publish method

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/io/email/sink/EmailSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/email/sink/EmailSink.java
@@ -546,12 +546,14 @@ public class EmailSink extends Sink {
                         throw new ConnectionUnavailableException("Error is encountered while connecting the smtp" 
                                 + " server by the email ClientConnector.", e);
                     } else {
-                        throw new RuntimeException("Error is encountered while sending the message by the email"
-                                + " ClientConnector with properties: " + emailProperties.toString() , e);
+                        log.error("Error is encountered while sending the message by the email, a socket connection " +
+                                "attempt failed for " + " ClientConnector with properties: " +
+                                emailProperties.toString() + ", events dropped '" + payload.toString() + "'", e);
                     }
                 } else {
-                    throw new RuntimeException("Error is encountered while sending the message by the email"
-                            + " ClientConnector with properties: " + emailProperties.toString() , e);
+                    log.error("Error is encountered while sending the message by the email"
+                            + " ClientConnector with properties: " + emailProperties.toString() +
+                            ", events dropped '" + payload.toString() + "'", e);
                 }
         }
     }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/email/sink/EmailSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/email/sink/EmailSink.java
@@ -546,8 +546,8 @@ public class EmailSink extends Sink {
                         throw new ConnectionUnavailableException("Error is encountered while connecting the smtp" 
                                 + " server by the email ClientConnector.", e);
                     } else {
-                        log.error("Error is encountered while sending the message by the email, a socket connection " +
-                                "attempt failed for " + " ClientConnector with properties: " +
+                        log.error("Error is encountered while sending the message by the email sink, " +
+                                "a socket connection attempt failed for the SMTP client connector with properties: " +
                                 emailProperties.toString() + ", events dropped '" + payload.toString() + "'", e);
                     }
                 } else {


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to fix the issue in email sink publish method exception handling.
According to the current implementation if there is an exception which is not an instance of  'MailConnectException' or 'ConnectException' then it creates new RuntimeException for each case and bubble up to the caller methods. But there is a problem when the caller methods do not handle the Runtime Exception properly.
This was noticed with the incident:https://github.com/wso2-extensions/siddhi-io-email/issues/43 and there the HA member change handler activation logic loop breaks due to bubbled up Runtime Exception from the Email sink publish method. By looking at the Runtime Exception trace log, the issue occured due to the SMTP server failed to send that message into the define email addresses.
To avoid this kind of issue, rather creating new Runtime Exception bubble up, the particular event log and drop in the Email sink publisher method.

## Goals
> Fix the exception handling issue in Email Sink publish method

## Approach
> Rather creating new Runtime Exception and bubble up from publish method, the particular payload log and drop in the Email sink publisher method

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A