### PR TITLE
Support concurrent publishing at Email Sink

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -61,6 +61,10 @@
             <artifactId>javax.mail</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-pool.wso2</groupId>
+            <artifactId>commons-pool</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/component/src/main/java/io/siddhi/extension/io/email/sink/transport/EmailClientConnectionPoolFactory.java
+++ b/component/src/main/java/io/siddhi/extension/io/email/sink/transport/EmailClientConnectionPoolFactory.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.io.email.sink.transport;
+
+import org.apache.commons.pool.BaseKeyedPoolableObjectFactory;
+import org.wso2.transport.email.contract.EmailClientConnector;
+import org.wso2.transport.email.contract.EmailConnectorFactory;
+import org.wso2.transport.email.exception.EmailConnectorException;
+
+import java.util.Map;
+
+/**
+ * The abstract class that needs to be implemented when supporting a new non-secure transport
+ * to mainly create, validate and terminate  the client to the endpoint.
+ */
+public class EmailClientConnectionPoolFactory extends BaseKeyedPoolableObjectFactory {
+    private EmailClientConnector emailClientConnector;
+
+    public EmailClientConnectionPoolFactory(EmailConnectorFactory emailConnectorFactory,
+                                            Map<String, String> clientProperties) throws EmailConnectorException {
+        emailClientConnector = emailConnectorFactory.createEmailClientConnector();
+        emailClientConnector.init(clientProperties);
+    }
+
+    @Override
+    public Object makeObject(Object key) throws EmailConnectorException {
+        if (!emailClientConnector.isConnected()) {
+            emailClientConnector.connect();
+        }
+        return emailClientConnector;
+    }
+
+    @Override
+    public boolean validateObject(Object key, Object obj) {
+        return obj != null && ((EmailClientConnector) obj).isConnected();
+    }
+
+    public void destroyObject(Object key, Object obj) {
+        if (obj != null) {
+            ((EmailClientConnector) obj).disconnect();
+        }
+    }
+}

--- a/component/src/main/java/io/siddhi/extension/io/email/sink/transport/EmailClientConnectionPoolManager.java
+++ b/component/src/main/java/io/siddhi/extension/io/email/sink/transport/EmailClientConnectionPoolManager.java
@@ -1,0 +1,57 @@
+/*
+*  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.siddhi.extension.io.email.sink.transport;
+
+import io.siddhi.extension.io.email.util.EmailConstants;
+import org.apache.commons.pool.impl.GenericKeyedObjectPool;
+import org.wso2.transport.email.contract.EmailConnectorFactory;
+import org.wso2.transport.email.exception.EmailConnectorException;
+
+import java.util.Map;
+
+/**
+ * This class is used hold the secure/non-secure connections for an Agent.
+ */
+
+public class EmailClientConnectionPoolManager {
+    private static GenericKeyedObjectPool connectionPool;
+
+    public static synchronized void initializeConnectionPool(EmailConnectorFactory emailConnectorFactory,
+                                                Map<String, String> clientProperties) throws EmailConnectorException {
+        EmailClientConnectionPoolFactory emailClientConnectionPoolFactory
+                = new EmailClientConnectionPoolFactory(emailConnectorFactory, clientProperties);
+        if (connectionPool == null) {
+            int poolSize = Integer.parseInt(clientProperties.get(EmailConstants.PUBLISHER_POOL_SIZE));
+            connectionPool = new GenericKeyedObjectPool();
+            connectionPool.setFactory(emailClientConnectionPoolFactory);
+            connectionPool.setMaxTotal(poolSize);
+            connectionPool.setMaxActive(poolSize);
+            connectionPool.setTestOnBorrow(true);
+            connectionPool.setWhenExhaustedAction(GenericKeyedObjectPool.WHEN_EXHAUSTED_BLOCK);
+        }
+    }
+
+    public static GenericKeyedObjectPool getConnectionPool() {
+        return connectionPool;
+    }
+
+    public static void uninitializeConnectionPool() {
+        connectionPool = null;
+    }
+}

--- a/component/src/main/java/io/siddhi/extension/io/email/util/EmailConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/email/util/EmailConstants.java
@@ -41,7 +41,8 @@ public class EmailConstants {
     public static final String BCC = "bcc";
     public static final String CC = "cc";
     public static final String ATTACHMENTS = "attachments";
-    public static final String MAIL_PUBLISHER_POOL_SIZE = "pool.size";
+    public static final String PUBLISHER_POOL_SIZE = "connection.pool.size";
+    public static final String EMAIL_CLIENT_CONNECTION_POOL_ID = "email_client_connection_pool";
 
     /**
      * Default values for the email sink configurations.

--- a/component/src/main/java/io/siddhi/extension/io/email/util/EmailConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/email/util/EmailConstants.java
@@ -41,6 +41,7 @@ public class EmailConstants {
     public static final String BCC = "bcc";
     public static final String CC = "cc";
     public static final String ATTACHMENTS = "attachments";
+    public static final String MAIL_PUBLISHER_POOL_SIZE = "pool.size";
 
     /**
      * Default values for the email sink configurations.

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
                 <version>${transport.email.version}</version>
             </dependency>
             <dependency>
+                <groupId>commons-pool.wso2</groupId>
+                <artifactId>commons-pool</artifactId>
+                <version>${commons.pool.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.siddhi.extension.map.xml</groupId>
                 <artifactId>siddhi-map-xml</artifactId>
                 <version>${xml.mapper.version}</version>
@@ -134,7 +139,7 @@
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <testng.version>6.8</testng.version>
         <jacoco.maven.version>0.7.9</jacoco.maven.version>
-        <transport.email.version>6.0.49</transport.email.version>
+        <transport.email.version>6.1.0</transport.email.version>
         <com.icegreen.version>1.5.5</com.icegreen.version>
         <com.sun.mail.version>1.5.6</com.sun.mail.version>
         <xml.mapper.version>5.0.2</xml.mapper.version>
@@ -142,6 +147,7 @@
         <json.mapper.version>5.0.2</json.mapper.version>
         <carbon.messaging.version>3.0.1</carbon.messaging.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <commons.pool.version>1.5.6.wso2v1</commons.pool.version>
     </properties>
 
 </project>


### PR DESCRIPTION
## Purpose
> Support Email sink to perform concurrent publishing

## Approach
> Maintain a connection pool and reuse the active connections, recreate connections when broken.
