### PR TITLE
Adds ability to set and send custom headers

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/io/email/util/EmailConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/email/util/EmailConstants.java
@@ -135,7 +135,9 @@ public class EmailConstants {
 
     //Constants for custom mail header implementation
     public static final String MAIL_CUSTOM_HEADER_IDENTIFIER = "customHeader_";
-    public static final String HEADER = "header";
+    public static final String HEADERS = "headers";
+    public static final String HEADER_SPLITTER_REGEX = "','";
+    public static final String HEADER_NAME_VALUE_SPLITTER = ":";
 
     /**
      * valid action for processed mail if store type is imap.

--- a/component/src/main/java/org/wso2/extension/siddhi/io/email/util/EmailConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/email/util/EmailConstants.java
@@ -133,6 +133,10 @@ public class EmailConstants {
      public static final String TEXT_PLAIN = "text/plain";
      public static final String TEXT_HTML = "text/html";
 
+    //Constants for custom mail header implementation
+    public static final String MAIL_CUSTOM_HEADER_IDENTIFIER = "customHeader_";
+    public static final String HEADER = "header";
+
     /**
      * valid action for processed mail if store type is imap.
      */

--- a/component/src/test/java/org/wso2/extension/siddhi/io/email/sink/EmailSinkTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/email/sink/EmailSinkTestCase.java
@@ -634,7 +634,8 @@ public class EmailSinkTestCase {
         masterConfigs.put("sink.email.host", "localhost");
         masterConfigs.put("sink.email.ssl.enable", "false");
         masterConfigs.put("sink.email.auth", "false");
-        masterConfigs.put("sink.email.header.email-header-name", "custom-email-header-value");
+        masterConfigs.put("sink.email.headers", "'email-header-name1:custom-email-header-value1',"
+                + "'email-header-name2:custom-email-header-value2'");
 
         SiddhiManager siddhiManager = new SiddhiManager();
         InMemoryConfigManager inMemoryConfigManager = new InMemoryConfigManager(masterConfigs, null);
@@ -664,9 +665,11 @@ public class EmailSinkTestCase {
 
         mailServer.waitForIncomingEmail(5000, 1);
         MimeMessage[] messages = mailServer.getReceivedMessages();
-        assertEquals(messages.length, 1, "Send two messages.");
-        Assert.assertEquals(messages[0].getHeader("email-header-name").length, 1);
-        Assert.assertEquals(messages[0].getHeader("email-header-name")[0], "custom-email-header-value");
+        assertEquals(messages.length, 1, "Send one messages.");
+        Assert.assertEquals(messages[0].getHeader("email-header-name1").length, 1);
+        Assert.assertEquals(messages[0].getHeader("email-header-name1")[0], "custom-email-header-value1");
+        Assert.assertEquals(messages[0].getHeader("email-header-name2").length, 1);
+        Assert.assertEquals(messages[0].getHeader("email-header-name2")[0], "custom-email-header-value2");
         siddhiAppRuntime.shutdown();
     }
 }

--- a/component/src/test/java/org/wso2/extension/siddhi/io/email/sink/EmailSinkTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/email/sink/EmailSinkTestCase.java
@@ -620,4 +620,53 @@ public class EmailSinkTestCase {
         assertTrue(messages[0].getSubject().contains("FooStream"));
         siddhiAppRuntime.shutdown();
     }
+
+    @Test(description = "Configure Siddhi to send email with custom headers")
+    public void emailSinkTest12() throws IOException, MessagingException, InterruptedException {
+        log.info("EmailSinkTest12 : Configure Siddhi to send email with custom headers");
+        // setup user on the mail server
+        mailServer = new GreenMail(ServerSetupTest.SMTP);
+        mailServer.start();
+        mailServer.setUser(ADDRESS, USERNAME, PASSWORD);
+
+        Map<String, String> masterConfigs = new HashMap<>();
+        masterConfigs.put("sink.email.port", "3025");
+        masterConfigs.put("sink.email.host", "localhost");
+        masterConfigs.put("sink.email.ssl.enable", "false");
+        masterConfigs.put("sink.email.auth", "false");
+        masterConfigs.put("sink.email.header.email-header-name", "custom-email-header-value");
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        InMemoryConfigManager inMemoryConfigManager = new InMemoryConfigManager(masterConfigs, null);
+        inMemoryConfigManager.generateConfigReader("sink", "email");
+        siddhiManager.setConfigManager(inMemoryConfigManager);
+        String streams = "" +
+                "@App:name('TestSiddhiApp')"
+                + "define stream FooStream (symbol string, price float, volume long); "
+                + "@sink(type='email', @map(type='text') ,"
+                + " username ='" + USERNAME + "',"
+                + " address ='" + ADDRESS + "',"
+                + " password= '" + PASSWORD + "',"
+                + " subject='FooStream-{{symbol}}' ,"
+                + " to='to@localhost')"
+                + " define stream BarStream (symbol string, price float, volume long); ";
+
+        String query = "" +
+                "from FooStream " +
+                "select * " +
+                "insert into BarStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("FooStream");
+        siddhiAppRuntime.start();
+
+        stockStream.send(new Object[]{"WSO2", 55.6f, 100L});
+
+        mailServer.waitForIncomingEmail(5000, 1);
+        MimeMessage[] messages = mailServer.getReceivedMessages();
+        assertEquals(messages.length, 1, "Send two messages.");
+        Assert.assertEquals(messages[0].getHeader("email-header-name").length, 1);
+        Assert.assertEquals(messages[0].getHeader("email-header-name")[0], "custom-email-header-value");
+        siddhiAppRuntime.shutdown();
+    }
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,8 +27,10 @@ extra:
     link: https://www.linkedin.com/groups/13553064
 markdown_extensions:
 - admonition
-- toc(permalink=true)
-- codehilite(guess_lang=false)
+- toc:
+  permalink: true
+- codehilite:
+  guess_lang: false
 pages:
 - Welcome: index.md
 - API Docs:

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <testng.version>6.8</testng.version>
         <jacoco.maven.version>0.7.9</jacoco.maven.version>
-        <transport.email.version>6.1.0</transport.email.version>
+        <transport.email.version>6.1.1</transport.email.version>
         <com.icegreen.version>1.5.5</com.icegreen.version>
         <com.sun.mail.version>1.5.6</com.sun.mail.version>
         <xml.mapper.version>4.0.18</xml.mapper.version>


### PR DESCRIPTION
## Purpose
Adds support to send custom headers though email sink. Users can pass custom headers as parameters in sink configuration which will be populated in the out going email as headers.

Fixes https://github.com/siddhi-io/siddhi-io-email/issues/57 ...

## Approach
Introduced a convention to add custom headers to sink configurations so that we can handle them separately. There can be any number of headers concatenated in following format. 'header1:value1','header2:value2'
Each header will be added to outgoing message separately.

## Documentation
Added to the sink class

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
